### PR TITLE
Fix for GetAtt failures during Stack Updates

### DIFF
--- a/lambda/ses_wait_for_verification_and_create_rule_set.py
+++ b/lambda/ses_wait_for_verification_and_create_rule_set.py
@@ -56,11 +56,14 @@ class DomainVerifierAndRuleSetCreator:
             if self.request_type in ['Create', 'Update']:
                 self.wait_for_ses_domain_verification()
 
+                email_address = 'admin@' + self.domain
+                response_data['EmailAddress'] = email_address
+                response_data['Domain'] = self.domain
+                
                 if self.request_type == 'Create':
                     result = self.ses.describe_active_receipt_rule_set()
                     rule_exists = False
                     rule_names = []
-                    email_address = 'admin@' + self.domain
 
                     if 'Metadata' in result and 'Name' in result['Metadata']:
                         self.rule_set_name = result['Metadata']['Name']
@@ -73,8 +76,6 @@ class DomainVerifierAndRuleSetCreator:
                     if not rule_exists:
                         self.create_rule(email_address, rule_names)
 
-                    response_data['EmailAddress'] = email_address
-                    response_data['Domain'] = self.domain
 
             elif self.request_type == 'Delete':
                 result = self.ses.describe_active_receipt_rule_set()


### PR DESCRIPTION
Needed to move lines required for !GetAtt sesEmailAddress.Domain to return information during a Cloud Formation Stack Update, else the sslCertificate Resource Update fails due to it's dependency on sesEmailAddress.Domain in it's DomainValidateOptions.